### PR TITLE
Create Default.sublime-commands

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -1,0 +1,6 @@
+[
+    {
+        "caption": "PHP CodeBeautifier",
+        "command": "php_cbf",
+    },
+]


### PR DESCRIPTION
Adds PHP CofeBeauftifier command to the Sublime [Command Palette](http://docs.sublimetext.info/en/latest/reference/command_palette.html) (Ctrl-Shift-P) so users don't have to remember the shortkey.
