### PR TITLE
Allow override of 'level' setting in project / syntax .sublime-settings file

### DIFF
--- a/phpcbf.py
+++ b/phpcbf.py
@@ -9,7 +9,7 @@ class PhpCbfCommand(sublime_plugin.TextCommand):
         if cur_syntax not in syntaxes:
             return
         path = settings.get('path', "")
-        level = settings.get('level', 'psr2')
+        level = self.view.settings().get('phpcbf.level', False) or settings.get('level', 'psr2')
         patch = settings.get('patch', False)
         suffix = settings.get('suffix', '')
         sniffs = settings.get('sniffs', '')


### PR DESCRIPTION
This will allow users to set project specific phpcs rules for phpcbf to follow.

Use case:
I work on a single Drupal Project for which I want to use the Drupal coding standard.  Globally I want to use PSR2.  Currently I can only set the `leve`' parameter in my User `phpcbf.sublime-settings` file, but this will apply to all projects.

Here I can add a setting to my `.sublime-project` file:

```
{
    "settings": {
        ...
        "phpcbf.level": "/path/to/my/drupal-phpcs.xml"
    }
}
```

And only this project will use the Drupal standards.